### PR TITLE
Fix: Ingress compatible with k8s >= 1.18 and liveness/healthcheck on pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ service:
 Note: You need the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/) installed and configured properly.
 
 1. Enable ingress
-2. Add host and path */**
+2. Add *host*, *path* *`/*`* and *pathType* `ImplementationSpecific`
 3. Add annotations for AWS LB Controller
 4. A SSL certificate at AWS Certificate Manager (either for the hostname, here `ethadapter.mydomain.com` or wildcard `*.mydomain.com`)
 
@@ -105,10 +105,16 @@ Configuration file *my-config.yaml*
 ```yaml
 ingress:
   enabled: true
+  # Let AWS LB Controller handle the ingress (default className is alb)
+  # Note: Use className instead of 'kubernetes.io/ingress.class' which is deprecated since 1.18
+  # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+  className: alb
   hosts:
     - host: ethadapter.mydomain.com
       # Path must be /* for ALB to match all paths
-      paths: ["/*"]
+      paths:
+        - path: /*
+          pathType: ImplementationSpecific
   # For full list of annotations for AWS LB Controller, see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/
   annotations:
     # The ARN of the existing SSL Certificate at AWS Certificate Manager
@@ -131,8 +137,6 @@ ingress:
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     # Use target type IP which is the case if the service type is ClusterIP
     alb.ingress.kubernetes.io/target-type: ip
-    # Let AWS LB Controller handle the ingress
-    kubernetes.io/ingress.class: alb
 
 config:
   rpcAddress: "rpcAddress_value"

--- a/ethadapter/README.md
+++ b/ethadapter/README.md
@@ -20,9 +20,11 @@ A Helm chart for Pharma Ledger Ethereum Adapter Service
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Ingress annotations. For AWS LB Controller, see [https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/) For Azure Application Gateway Ingress Controller, see [https://azure.github.io/application-gateway-kubernetes-ingress/annotations/](https://azure.github.io/application-gateway-kubernetes-ingress/annotations/) For NGINX Ingress Controller, see [https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) For Traefik Ingress Controller, see [https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#annotations](https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#annotations) |
+| ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` | Whether to create ingress or not. Note: For ingress an Ingress Controller (e.g. AWS LB Controller, NGINX Ingress Controller, Traefik, ...) is required and service.type should be ClusterIP or NodePort depending on your configuration |
 | ingress.hosts[0].host | string | `"ethadapter.some-pharma-company.com"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` | nameOverride replaces the name of the chart in the Chart.yaml file, when this is used to construct Kubernetes object names. From [https://stackoverflow.com/questions/63838705/what-is-the-difference-between-fullnameoverride-and-nameoverride-in-helm](https://stackoverflow.com/questions/63838705/what-is-the-difference-between-fullnameoverride-and-nameoverride-in-helm) |
 | nodeSelector | object | `{}` | Node Selectors in order to assign pods to certain nodes. See [https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) |

--- a/ethadapter/templates/deployment.yaml
+++ b/ethadapter/templates/deployment.yaml
@@ -61,6 +61,14 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /check
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /check
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/ethadapter/templates/ingress.yaml
+++ b/ethadapter/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ethadapter.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +42,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/ethadapter/values.yaml
+++ b/ethadapter/values.yaml
@@ -78,6 +78,7 @@ ingress:
   # -- Whether to create ingress or not.
   # Note: For ingress an Ingress Controller (e.g. AWS LB Controller, NGINX Ingress Controller, Traefik, ...) is required and service.type should be ClusterIP or NodePort depending on your configuration
   enabled: false
+  className: ""
   # -- Ingress annotations.
   # For AWS LB Controller, see [https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/)
   # For Azure Application Gateway Ingress Controller, see [https://azure.github.io/application-gateway-kubernetes-ingress/annotations/](https://azure.github.io/application-gateway-kubernetes-ingress/annotations/)
@@ -89,7 +90,9 @@ ingress:
   # -- A list of hostnames and path(s) to listen at the Ingress Controller
   hosts:
     - host: ethadapter.some-pharma-company.com
-      paths: []
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/tests/data/aws_lb_controller_ingress.yaml
+++ b/tests/data/aws_lb_controller_ingress.yaml
@@ -3,10 +3,16 @@
 #
 ingress:
   enabled: true
+  # Let AWS LB Controller handle the ingress (default className is alb)
+  # Note: Use className instead of 'kubernetes.io/ingress.class' which is deprecated since 1.18
+  # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+  className: alb
   hosts:
     - host: ethadapter.mydomain.com
       # Path must be /* for ALB to match all paths
-      paths: ["/*"]
+      paths:
+        - path: /*
+          pathType: ImplementationSpecific
   # For full list of annotations for AWS LB Controller, see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/ingress/annotations/
   annotations:
     # The ARN of the existing SSL Certificate at AWS Certificate Manager
@@ -25,12 +31,10 @@ ingress:
     alb.ingress.kubernetes.io/inbound-cidrs: 8.8.8.8/32 
     # Use internet facing
     alb.ingress.kubernetes.io/scheme: internet-facing
-    # Use most current encryption ciphers
+    # Use most current (as of Dec 2021) encryption ciphers
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     # Use target type IP which is the case if the service type is ClusterIP
     alb.ingress.kubernetes.io/target-type: ip
-    # Let AWS LB Controller handle the ingress
-    kubernetes.io/ingress.class: alb
 
 config:
   rpcAddress: "rpcAddress_value"


### PR DESCRIPTION
Fixes:
- pathType was missing, now default is ImplementationSpecific
- `Get error "unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend" when switch from v1beta1 to v1 in Kubernetes Ingress` - See [link](https://stackoverflow.com/questions/64125048/get-error-unknown-field-servicename-in-io-k8s-api-networking-v1-ingressbacken)
- use className for ingress instead of annotation